### PR TITLE
feat(error-label): custom styling for error message state

### DIFF
--- a/TextFieldEffects/TextFieldEffects/HoshiTextField.swift
+++ b/TextFieldEffects/TextFieldEffects/HoshiTextField.swift
@@ -116,24 +116,24 @@ typealias VoidClosure = () -> Void
     
     private var placeholderLabelOriginalText: String?
     private var placeholderFont: UIFont? = UIFont(name: "Roboto-Regular", size: 13)
-	private var errorFont: UIFont? = UIFont(name: "Roboto-Regular", size: 10)
+    private var errorFont: UIFont? = UIFont(name: "Roboto-Regular", size: 10)
     private var height: CGFloat = 45
 	
-	private var errorLabel = UILabel()
+    private var errorLabel = UILabel()
 	
     open func showError(message: String) {
-		errorLabel.text = message
-		errorLabel.textColor = borderActiveColor
-		errorLabel.sizeToFit()
-		errorLabel.isHidden = false
-		
-		activeBorderLayer.frame = rectForBorder(borderThicknessActive)
-		activeBorderLayer.isHidden = false
+	errorLabel.text = message
+	errorLabel.textColor = borderActiveColor
+	errorLabel.sizeToFit()
+	errorLabel.isHidden = false
+
+	activeBorderLayer.frame = rectForBorder(borderThicknessActive)
+	activeBorderLayer.isHidden = false
     }
     
     open func hideError() {
-		errorLabel.isHidden = true
-		activeBorderLayer.isHidden = true
+	errorLabel.isHidden = true
+	activeBorderLayer.isHidden = true
     }
     
     // MARK: - TextFieldEffects
@@ -145,7 +145,7 @@ typealias VoidClosure = () -> Void
                        height: height)
         configurePlaceholderLabelFrame()
         configurePlaceholderFont()
-		configureErrorLabel()
+	configureErrorLabel()
         updateBorder()
         updatePlaceholder()
         
@@ -156,7 +156,7 @@ typealias VoidClosure = () -> Void
     }
     
     override open func animateViewsForTextEntry() {
-		hideError()
+	hideError()
         guard let text = text else {
             return
         }
@@ -237,11 +237,11 @@ typealias VoidClosure = () -> Void
         }
     }
 	
-	private func configureErrorLabel() {
-		errorLabel.frame.origin = activePlaceholderPoint
-		errorLabel.font = errorFont
-		errorLabel.isHidden = true
-	}
+    private func configureErrorLabel() {
+	errorLabel.frame.origin = activePlaceholderPoint
+	errorLabel.font = errorFont
+	errorLabel.isHidden = true
+    }
     
     private func updateBorder() {
         inactiveBorderLayer.frame = rectForBorder(borderThicknessInactive)

--- a/TextFieldEffects/TextFieldEffects/HoshiTextField.swift
+++ b/TextFieldEffects/TextFieldEffects/HoshiTextField.swift
@@ -116,22 +116,24 @@ typealias VoidClosure = () -> Void
     
     private var placeholderLabelOriginalText: String?
     private var placeholderFont: UIFont? = UIFont(name: "Roboto-Regular", size: 13)
+	private var errorFont: UIFont? = UIFont(name: "Roboto-Regular", size: 10)
     private var height: CGFloat = 45
-    
+	
+	private var errorLabel = UILabel()
+	
     open func showError(message: String) {
-        placeholderLabelOriginalText = placeholderLabel.text
-        placeholderLabel.textColor = borderActiveColor
-        placeholderLabel.text = message
-        activeBorderLayer.frame = rectForBorder(borderThicknessActive)
-        activeBorderLayer.isHidden = false
-        placeholderLabel.sizeToFit()
+		errorLabel.text = message
+		errorLabel.textColor = borderActiveColor
+		errorLabel.sizeToFit()
+		errorLabel.isHidden = false
+		
+		activeBorderLayer.frame = rectForBorder(borderThicknessActive)
+		activeBorderLayer.isHidden = false
     }
     
     open func hideError() {
-        placeholderLabel.text = placeholderLabelOriginalText ?? placeholderLabel.text
-        placeholderLabel.textColor = placeholderColorEmptyState
-        activeBorderLayer.isHidden = true
-        placeholderLabel.sizeToFit()
+		errorLabel.isHidden = true
+		activeBorderLayer.isHidden = true
     }
     
     // MARK: - TextFieldEffects
@@ -143,15 +145,18 @@ typealias VoidClosure = () -> Void
                        height: height)
         configurePlaceholderLabelFrame()
         configurePlaceholderFont()
+		configureErrorLabel()
         updateBorder()
         updatePlaceholder()
         
         layer.addSublayer(inactiveBorderLayer)
         layer.addSublayer(activeBorderLayer)
         addSubview(placeholderLabel)
+		addSubview(errorLabel)
     }
     
     override open func animateViewsForTextEntry() {
+		hideError()
         guard let text = text else {
             return
         }
@@ -231,6 +236,12 @@ typealias VoidClosure = () -> Void
             placeholderFont = font
         }
     }
+	
+	private func configureErrorLabel() {
+		errorLabel.frame.origin = activePlaceholderPoint
+		errorLabel.font = errorFont
+		errorLabel.isHidden = true
+	}
     
     private func updateBorder() {
         inactiveBorderLayer.frame = rectForBorder(borderThicknessInactive)

--- a/TextFieldEffects/TextFieldEffects/HoshiTextField.swift
+++ b/TextFieldEffects/TextFieldEffects/HoshiTextField.swift
@@ -152,7 +152,7 @@ typealias VoidClosure = () -> Void
         layer.addSublayer(inactiveBorderLayer)
         layer.addSublayer(activeBorderLayer)
         addSubview(placeholderLabel)
-		addSubview(errorLabel)
+	addSubview(errorLabel)
     }
     
     override open func animateViewsForTextEntry() {


### PR DESCRIPTION
Custom error message state to match designs. 

Design:
https://travelbank.invisionapp.com/share/6FBKY36WK#/screens/268269381

![img_0259](https://user-images.githubusercontent.com/12732454/34266500-f80a9be4-e63e-11e7-9226-c840f840aa6a.PNG)

![ezgif-4-9cb6d6f485](https://user-images.githubusercontent.com/12732454/34267960-8ed1e4e2-e644-11e7-82fc-cd5a83ecb0a9.gif)
