### PR TITLE
fix(labels): disappearing labels

### DIFF
--- a/TextFieldEffects/TextFieldEffects/HoshiTextField.swift
+++ b/TextFieldEffects/TextFieldEffects/HoshiTextField.swift
@@ -158,7 +158,9 @@ typealias VoidClosure = () -> Void
 	override open func animateViewsForTextEntry() {
 		hideError()
 		
-		UIView.animate(withDuration: 0.35,
+		guard let text = text else { return }
+		let duration = text.isEmpty ? 0.35 : 0.0
+		UIView.animate(withDuration: duration,
 					   delay: 0.0,
 					   usingSpringWithDamping: 0.8,
 					   initialSpringVelocity: 1.0,

--- a/TextFieldEffects/TextFieldEffects/HoshiTextField.swift
+++ b/TextFieldEffects/TextFieldEffects/HoshiTextField.swift
@@ -157,6 +157,7 @@ typealias VoidClosure = () -> Void
     
 	override open func animateViewsForTextEntry() {
 		hideError()
+		
 		UIView.animate(withDuration: 0.35,
 					   delay: 0.0,
 					   usingSpringWithDamping: 0.8,
@@ -170,22 +171,19 @@ typealias VoidClosure = () -> Void
 	}
     
     override open func animateViewsForTextDisplay() {
-        guard let text = text else {
-            return
-        }
-        
-        if text.isEmpty {
-            UIView.animate(withDuration: 0.35,
-                           delay: 0.0,
-                           usingSpringWithDamping: 0.8,
-                           initialSpringVelocity: 2.0,
-                           options: UIViewAnimationOptions.beginFromCurrentState,
-                           animations: ({
-                            self.viewForTextDisplayAnimationClosure()
-                           }), completion: { _  in
-                            self.animationCompletionHandler?(.textDisplay)
-            })
-        }
+        guard let text = text,
+			  text.isEmpty else { return }
+		
+		UIView.animate(withDuration: 0.35,
+					   delay: 0.0,
+					   usingSpringWithDamping: 0.8,
+					   initialSpringVelocity: 2.0,
+					   options: UIViewAnimationOptions.beginFromCurrentState,
+					   animations: ({
+						self.viewForTextDisplayAnimationClosure()
+					   }), completion: { _  in
+						self.animationCompletionHandler?(.textDisplay)
+		})
     }
     
     // MARK: - Private

--- a/TextFieldEffects/TextFieldEffects/HoshiTextField.swift
+++ b/TextFieldEffects/TextFieldEffects/HoshiTextField.swift
@@ -155,26 +155,19 @@ typealias VoidClosure = () -> Void
 		addSubview(errorLabel)
     }
     
-    override open func animateViewsForTextEntry() {
-	hideError()
-        guard let text = text else {
-            return
-        }
-        
-        if text.isEmpty {
-            UIView.animate(withDuration: 0.35,
-                           delay: 0.0,
-                           usingSpringWithDamping: 0.8,
-                           initialSpringVelocity: 1.0,
-                           options: .beginFromCurrentState,
-                           animations: ({
-                            self.viewForTextEntryAnimationClosure()
-                           }), completion: { _ in
-                            self.animationCompletionHandler?(.textEntry)
-                            
-            })
-        }
-    }
+	override open func animateViewsForTextEntry() {
+		hideError()
+		UIView.animate(withDuration: 0.35,
+					   delay: 0.0,
+					   usingSpringWithDamping: 0.8,
+					   initialSpringVelocity: 1.0,
+					   options: .beginFromCurrentState,
+					   animations: ({
+						self.viewForTextEntryAnimationClosure()
+					}), completion: { _ in
+						self.animationCompletionHandler?(.textEntry)
+		})
+	}
     
     override open func animateViewsForTextDisplay() {
         guard let text = text else {


### PR DESCRIPTION
When in the background for a while, the layout is sometimes invalidated and is redrawn when opening the app again. When the labels are drawn, some properties are set back to default values (like font and frame) and then if necessary, the animation is run to put the label back into the corner. When drawing/updating the placeholder, there are two conditions that cause this animation to run (line 256): 

1. The text field is first responder
2. The text field has text entered into it

In our case, #2 should cause the animation to happen. However the animation was not running because there was an additional check that the label in fact does _not_ have text. I don't believe this check should be there, and removing it solves the problem by allowing the animation to run. 